### PR TITLE
Spelling Error

### DIFF
--- a/src/450DSAFinal.js
+++ b/src/450DSAFinal.js
@@ -1746,7 +1746,7 @@ export default [
 			},
 			{
 				Topic: "Binary Search Trees",
-				Problem: "Count BST ndoes that lie in a given range",
+				Problem: "Count BST nodes that lie in a given range",
 				Done: false,
 				Bookmark: false,
 				Notes: "",


### PR DESCRIPTION
In the BST section there is a spelling error.
No. 15 -- "nodes" is written is "ndoes".
The spelling has been corrected.